### PR TITLE
Introduce svelte-i18n for translations.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1023,6 +1023,21 @@
         "to-fast-properties": "^2.0.0"
       }
     },
+    "@formatjs/intl-unified-numberformat": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/@formatjs/intl-unified-numberformat/-/intl-unified-numberformat-3.3.3.tgz",
+      "integrity": "sha512-dic7DA8REMy8gkidkCSoWqTjaLIlCyLJ5fDtlgHzK/ftwxAlbSSHkbeozZ/IKQDPbbcSppI/t9hp9KT+co/Ksg==",
+      "dev": true,
+      "requires": {
+        "@formatjs/intl-utils": "^2.2.2"
+      }
+    },
+    "@formatjs/intl-utils": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/@formatjs/intl-utils/-/intl-utils-2.2.2.tgz",
+      "integrity": "sha512-rKINaMRYH3FeNwYjEQwPtsA0kP2/hLLMB9mLi/QYfszz/huTqkInFmYilFRCX4oLlhFXDK5UQQMGNfEavN02Sg==",
+      "dev": true
+    },
     "@polka/url": {
       "version": "0.5.0",
       "resolved": "https://registry.npmjs.org/@polka/url/-/url-0.5.0.tgz",
@@ -1047,6 +1062,15 @@
           "integrity": "sha512-1fMXF3YP4pZZVozF8j/ZLfvnR8NSIljt56UhbZ5PeeDmmGHpgpdwQt7ITlGvYaQukCvuBRMLEiKiYC+oeIg4cg==",
           "dev": true
         }
+      }
+    },
+    "@rollup/plugin-json": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@rollup/plugin-json/-/plugin-json-4.0.2.tgz",
+      "integrity": "sha512-t4zJMc98BdH42mBuzjhQA7dKh0t4vMJlUka6Fz0c+iO5IVnWaEMiYBy1uBj9ruHZzXBW23IPDGL9oCzBkQ9Udg==",
+      "dev": true,
+      "requires": {
+        "@rollup/pluginutils": "^3.0.4"
       }
     },
     "@rollup/plugin-node-resolve": {
@@ -2870,6 +2894,18 @@
       "integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
       "dev": true
     },
+    "globalyzer": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/globalyzer/-/globalyzer-0.1.4.tgz",
+      "integrity": "sha512-LeguVWaxgHN0MNbWC6YljNMzHkrCny9fzjmEUdnF1kQ7wATFD1RHFRqA1qxaX2tgxGENlcxjOflopBwj3YZiXA==",
+      "dev": true
+    },
+    "globrex": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/globrex/-/globrex-0.1.2.tgz",
+      "integrity": "sha512-uHJgbwAMwNFf5mLst7IWLNg14x1CkeqglJb/K3doi4dw6q2IvAAmM/Y81kevy83wP+Sst+nutFTYOGg3d1lsxg==",
+      "dev": true
+    },
     "graceful-fs": {
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.3.tgz",
@@ -3007,6 +3043,31 @@
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
       "dev": true
+    },
+    "intl-format-cache": {
+      "version": "4.2.24",
+      "resolved": "https://registry.npmjs.org/intl-format-cache/-/intl-format-cache-4.2.24.tgz",
+      "integrity": "sha512-eea8rHu7ipmUilSd9+MCglgR07E+xJXmTYVFODmeLKsO3Psr/OrixDr6vWprz1whli7cwRdSc1/jHVBxrd+QBw==",
+      "dev": true
+    },
+    "intl-messageformat": {
+      "version": "7.8.4",
+      "resolved": "https://registry.npmjs.org/intl-messageformat/-/intl-messageformat-7.8.4.tgz",
+      "integrity": "sha512-yS0cLESCKCYjseCOGXuV4pxJm/buTfyCJ1nzQjryHmSehlptbZbn9fnlk1I9peLopZGGbjj46yHHiTAEZ1qOTA==",
+      "dev": true,
+      "requires": {
+        "intl-format-cache": "^4.2.21",
+        "intl-messageformat-parser": "^3.6.4"
+      }
+    },
+    "intl-messageformat-parser": {
+      "version": "3.6.4",
+      "resolved": "https://registry.npmjs.org/intl-messageformat-parser/-/intl-messageformat-parser-3.6.4.tgz",
+      "integrity": "sha512-RgPGwue0mJtoX2Ax8EmMzJzttxjnva7gx0Q7mKJ4oALrTZvtmCeAw5Msz2PcjW4dtCh/h7vN/8GJCxZO1uv+OA==",
+      "dev": true,
+      "requires": {
+        "@formatjs/intl-unified-numberformat": "^3.2.0"
+      }
     },
     "invariant": {
       "version": "2.2.4",
@@ -5094,6 +5155,32 @@
       "integrity": "sha512-m/dw52BZf+p6KYnyKLErIcGalu4pwJrQbUM7VZriRw6ZlJj1qMAZsLcIWzEB3I0hhdJwkKb7LrrvUIeqmbO92Q==",
       "dev": true
     },
+    "svelte-i18n": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/svelte-i18n/-/svelte-i18n-3.0.3.tgz",
+      "integrity": "sha512-2pJZwrMuXW8UtkzQGdld0AuwMDnzekDGXSPUdbTu+Th5ByPXYRnOZip3nIVruFzskta1JppYwUZ0U8vvgirkQg==",
+      "dev": true,
+      "requires": {
+        "commander": "^4.0.1",
+        "estree-walker": "^0.9.0",
+        "intl-messageformat": "^7.5.2",
+        "tiny-glob": "^0.2.6"
+      },
+      "dependencies": {
+        "commander": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-4.1.1.tgz",
+          "integrity": "sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==",
+          "dev": true
+        },
+        "estree-walker": {
+          "version": "0.9.0",
+          "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-0.9.0.tgz",
+          "integrity": "sha512-12U47o7XHUX329+x3FzNVjCx3SHEzMF0nkDv7r/HnBzX/xNTKxajBk6gyygaxrAFtLj39219oMfbtxv4KpaOiA==",
+          "dev": true
+        }
+      }
+    },
     "svgo": {
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/svgo/-/svgo-1.3.2.tgz",
@@ -5139,6 +5226,16 @@
       "resolved": "https://registry.npmjs.org/timsort/-/timsort-0.3.0.tgz",
       "integrity": "sha1-QFQRqOfmM5/mTbmiNN4R3DHgK9Q=",
       "dev": true
+    },
+    "tiny-glob": {
+      "version": "0.2.6",
+      "resolved": "https://registry.npmjs.org/tiny-glob/-/tiny-glob-0.2.6.tgz",
+      "integrity": "sha512-A7ewMqPu1B5PWwC3m7KVgAu96Ch5LA0w4SnEN/LbDREj/gAD0nPWboRbn8YoP9ISZXqeNAlMvKSKoEuhcfK3Pw==",
+      "dev": true,
+      "requires": {
+        "globalyzer": "^0.1.0",
+        "globrex": "^0.1.1"
+      }
     },
     "tinydate": {
       "version": "1.2.0",

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "@babel/preset-env": "^7.9.0",
     "@babel/runtime": "^7.9.2",
     "@rollup/plugin-commonjs": "^11.0.2",
+    "@rollup/plugin-json": "^4.0.2",
     "@rollup/plugin-node-resolve": "^7.1.1",
     "core-js": "^3.6.4",
     "rollup": "^1.32.1",
@@ -21,7 +22,8 @@
     "rollup-plugin-postcss": "^2.5.0",
     "rollup-plugin-svelte": "^5.2.0",
     "rollup-plugin-terser": "^5.3.0",
-    "svelte": "^3.20.1"
+    "svelte": "^3.20.1",
+    "svelte-i18n": "^3.0.3"
   },
   "dependencies": {
     "bulma": "^0.8.1",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -5,6 +5,7 @@ import livereload from 'rollup-plugin-livereload'
 import { terser } from 'rollup-plugin-terser'
 import postcss from 'rollup-plugin-postcss'
 import babel from 'rollup-plugin-babel'
+import json from '@rollup/plugin-json';
 
 const production = !process.env.ROLLUP_WATCH
 
@@ -37,6 +38,7 @@ export default {
     }),
     postcss(),
     commonjs(),
+    json(),
     production &&
       babel({
         extensions: ['.js', '.mjs', '.html', '.svelte'],
@@ -68,7 +70,7 @@ export default {
 
     // If we're building for production (npm run build
     // instead of npm run dev), minify
-    production && terser()
+    production && terser(),
   ],
   watch: {
     clearScreen: false

--- a/src/components/Filters.svelte
+++ b/src/components/Filters.svelte
@@ -1,4 +1,5 @@
 <script>
+    import { _ } from 'svelte-i18n'
     import {data, filters} from '../stores'
     import GeneralSearch from './GeneralSearch.svelte'
     import {capitalizeFirstLetter} from '../utils/textFormating'
@@ -129,7 +130,7 @@
 
 <GeneralSearch {textSearch}/>
 
-<CategoryFilter name="Categories" categories={overallCategoryItems}
+<CategoryFilter name={$_('category_filter_header')} categories={overallCategoryItems}
                 on:update={e => overallCategoryItems = e.detail} {customColors}/>
 
 <br>

--- a/src/i18n-dictionaries/en.json
+++ b/src/i18n-dictionaries/en.json
@@ -1,0 +1,3 @@
+{
+  "category_filter_header": "Categories"
+}

--- a/src/i18n-dictionaries/es.json
+++ b/src/i18n-dictionaries/es.json
@@ -1,0 +1,3 @@
+{
+  "category_filter_header": "Categorías"
+}

--- a/src/i18n.js
+++ b/src/i18n.js
@@ -1,0 +1,12 @@
+import { addMessages, init, getLocaleFromNavigator } from 'svelte-i18n'
+
+import en from './i18n-dictionaries/en.json'
+import es from './i18n-dictionaries/es.json'
+
+addMessages('en', en)
+addMessages('es', es)
+
+init({
+  fallbackLocale: 'en',
+  initialLocale: getLocaleFromNavigator(),
+})

--- a/src/main.js
+++ b/src/main.js
@@ -1,4 +1,5 @@
 import App from './App.svelte'
+import './i18n.js'
 
 //polyfill
 import 'whatwg-fetch'


### PR DESCRIPTION
This commit:
 - Adds the dependency
 - Initializes support for internationalization in src/i18n.js.
 - Loads the user's preferred locale based on window.navigator.language.
   I don't believe this will make a correct choice very often, and we
   should offer links in a follow-up PR to allow the user to change
   their language.
 - Create dictionary files in `src/i18n-dictionaries` where we can keep
   translated strings. For now I included English and Spanish.
 - Introduce one translated string for testing.