### PR TITLE
Hide source within Last Updated

### DIFF
--- a/src/components/Details.svelte
+++ b/src/components/Details.svelte
@@ -3,9 +3,11 @@
     import {details} from '../stores'
     import HideWhenEmpty from './details/HideWhenEmpty.svelte'
     import MarkdownField from './details/MarkdownField.svelte'
+    import LastUpdate from './details/LastUpdated.svelte'
 
     import {getValidUrl, getValidInstagram} from '../utils/getValidUrl'
     import {formatPhoneNumber} from '../utils/textFormating'
+    import LastUpdated from "./details/LastUpdated.svelte";
 </script>
 
 {#if $details}
@@ -85,13 +87,9 @@
 
         <hr>
 
-        <p class="has-text-grey-light">{$_('details.last_updated', {values: { lastUpdated: $details.dateupdated} })}
-            ID: {$details.id}</p>
-        <HideWhenEmpty value={$details.sourceofinformationforopenclosedpleaseensurethereisasourceforclosedorgsbusinesses}>
-            <p>{@html $_('details.source_link', { values: {
-            url: getValidUrl($details.sourceofinformationforopenclosedpleaseensurethereisasourceforclosedorgsbusinesses)
-            }})}</p>
-        </HideWhenEmpty>
+        <LastUpdated lastUpdated={$details.dateupdated}
+                     source={$details.sourceofinformationforopenclosedpleaseensurethereisasourceforclosedorgsbusinesses}/>
+
     </div>
 {:else}
     <div class="content has-background-ter">

--- a/src/components/details/LastUpdated.svelte
+++ b/src/components/details/LastUpdated.svelte
@@ -1,0 +1,27 @@
+<script>
+    //if source is a link hyperlink lastUpdated, otherwise abbr if source isn't blank
+    import {_} from 'svelte-i18n'
+    import {getValidUrl} from '../../utils/getValidUrl'
+
+    export let lastUpdated = ''
+    export let source = ''
+
+
+    $: sourceIsLink = source.includes('http')
+</script>
+
+<p class="has-text-grey-light">
+    {#if sourceIsLink}
+        <a href={getValidUrl(source)}>{$_('details.last_updated', {values: { lastUpdated } })}</a>
+    {:else if source.trim().length > 0}
+        <abbr title={source}>{$_('details.last_updated', {values: { lastUpdated } })}</abbr>
+    {:else}
+        {$_('details.last_updated', {values: { lastUpdated } })}
+    {/if}
+</p>
+
+<style>
+    a:link {
+        color: #7297b6;
+    }
+</style>


### PR DESCRIPTION
This feature came from a conversion with Laura and Paul

> Laura: The Last Updated notes add value to the information, but I question having Source text (column V) appear in the user interface. I think of Source as a place for internal notes among the team. 
It was originally supposed to just be for proof of closures, but has evolved into the place I throw the latest IG post (just so the next person doesn't have to look it up if they have a question), or let you know I saw a sign, spoke to the owner, called, etc. 
Since we already have links to IG and website for each listing, the "click here" doesn't really add anything for businesses that already have an online presence, and it's a little confusing for those that don't, leading to a "can't find the page" message. Unless I'm missing something, I'd prefer to hide column V from the user.  
Thoughts?

>  Paul: agree that it’s confusing. I have been using Update notes instead of source text because if it isn’t a link it will show that error message when one clicks “source” on the site. I think it’s fine to leave as is but I agree source should be hidden on the site. The user should trust that we’re providing accurate info, as of whatever date that it displays.

> Zhi: I guess it can be hidden and shown (via tooltip) when the user hovers over the Last Updated text? 

This adds a the LastUpdated component which replaces Last Updated and Sources text.
- If the source text is a link it will hyperlink the Last Updated text
- Otherwise the text is abbreviated under the Last Updated text